### PR TITLE
Update environment ignore rules and refine workflow guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 .vscode
 bin
 .env
-.env.dev
+.env.test
+.env.staging
 .env.production
 .air.toml
 .claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ func main() {
 ## Development Workflow
 When adding a new API endpoint:
 1. Extend or create handler files under `internal/http/controller/<area>` (for example, `internal/http/controller/user/user_register.go`). Follow the existing `<feature>_<action>.go` naming and add matching `*_test.go` coverage.
-2. **REQUIRED**: Implement or extend business logic in `internal/pkg/<domain>` (e.g., `internal/pkg/user`, `internal/pkg/permission`) BEFORE writing controller code. Controllers MUST delegate to `internal/pkg/` and never contain business logic directly. Keep helpers reusable and include unit tests where practical.
+2. **REQUIRED**: Implement or extend business logic in `internal/pkg/<domain>` (e.g., `internal/pkg/user`, `internal/pkg/permission`) BEFORE writing controller code by default. Controllers MUST delegate to `internal/pkg/` for shared or reusable business logic. A controller MAY keep single-interface-only flow locally when the Single-Interface Scope/KISS override applies. Keep helpers reusable and include unit tests where practical.
 3. Wire routes in the corresponding router under `internal/http/route/<area>/api_route.go`, ensuring it implements `route.Router` and guards handlers with middleware as needed.
 4. If you introduce a brand-new router, register it in `internal/http/route/api_route.go` by appending it to the `routers` slice so it participates in `AttachRoutes`.
 5. For admin/protected capabilities, synchronise seeds between runtime and tests: update `cmd/kit/permission_seeder/permission_seeder.go` and mirror the same permission preset in `internal/test/fake/permission.go`; adjust `internal/test/fixture/domain/permission.go` or `internal/test/fixture/scenario/admin_api.go` when the admin fixture flow changes.

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-playground/mold/v4/modifiers"
 	_ "github.com/joho/godotenv/autoload"
 	"go.uber.org/fx"
+	"go.uber.org/fx/fxevent"
 )
 
 // @title Example API
@@ -21,6 +22,9 @@ func main() {
 
 	fx.New(
 		fx.StopTimeout(60*time.Second),
+		fx.WithLogger(func() fxevent.Logger {
+			return fxevent.NopLogger
+		}),
 		fx.Supply(booterConfig),
 		fx.Provide(
 			registrar.NewConfigLoader,

--- a/cmd/kit/http_route/http_route.go
+++ b/cmd/kit/http_route/http_route.go
@@ -8,10 +8,14 @@ import (
 	booter "github.com/chan-jui-huang/go-backend-package/v2/pkg/booter"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/fx"
+	"go.uber.org/fx/fxevent"
 )
 
 func main() {
 	fxApp := fx.New(
+		fx.WithLogger(func() fxevent.Logger {
+			return fxevent.NopLogger
+		}),
 		fx.Supply(booter.NewDefaultConfig()),
 		fx.Provide(
 			appregistrar.NewConfigLoader,

--- a/cmd/kit/permission_seeder/permission_seeder.go
+++ b/cmd/kit/permission_seeder/permission_seeder.go
@@ -9,6 +9,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/urfave/cli/v2"
 	"go.uber.org/fx"
+	"go.uber.org/fx/fxevent"
 	"gorm.io/gorm"
 
 	gormadapter "github.com/casbin/gorm-adapter/v3"
@@ -136,6 +137,9 @@ func (ps *permissionSeeder) appendPermissionsToRoles() {
 
 func main() {
 	fxApp := fx.New(
+		fx.WithLogger(func() fxevent.Logger {
+			return fxevent.NopLogger
+		}),
 		fx.Supply(booter.NewDefaultConfig()),
 		fx.Provide(
 			appregistrar.NewConfigLoader,

--- a/cmd/kit/rdbms_seeder/rdbms_seeder.go
+++ b/cmd/kit/rdbms_seeder/rdbms_seeder.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/joho/godotenv/autoload"
 	"github.com/urfave/cli/v2"
 	"go.uber.org/fx"
+	"go.uber.org/fx/fxevent"
 
 	"github.com/chan-jui-huang/go-backend-framework/v3/internal/migration/rdbms/seeder"
 	appregistrar "github.com/chan-jui-huang/go-backend-framework/v3/internal/registrar"
@@ -16,6 +17,9 @@ import (
 
 func main() {
 	fxApp := fx.New(
+		fx.WithLogger(func() fxevent.Logger {
+			return fxevent.NopLogger
+		}),
 		fx.Supply(booter.NewDefaultConfig()),
 		fx.Provide(
 			appregistrar.NewConfigLoader,

--- a/cmd/template/template.go
+++ b/cmd/template/template.go
@@ -5,10 +5,14 @@ import (
 	booter "github.com/chan-jui-huang/go-backend-package/v2/pkg/booter"
 	_ "github.com/joho/godotenv/autoload"
 	"go.uber.org/fx"
+	"go.uber.org/fx/fxevent"
 )
 
 func main() {
 	fxApp := fx.New(
+		fx.WithLogger(func() fxevent.Logger {
+			return fxevent.NopLogger
+		}),
 		fx.Supply(booter.NewDefaultConfig()),
 		fx.Provide(
 			appregistrar.NewConfigLoader,

--- a/internal/test/runtime/runtime.go
+++ b/internal/test/runtime/runtime.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-playground/mold/v4/modifiers"
 	"github.com/joho/godotenv"
 	"go.uber.org/fx"
+	"go.uber.org/fx/fxevent"
 	"go.uber.org/fx/fxtest"
 )
 
@@ -51,6 +52,9 @@ func NewRuntime(tb testing.TB, options RuntimeOptions) *Runtime {
 	app := fxtest.New(
 		tb,
 		fx.StopTimeout(60*time.Second),
+		fx.WithLogger(func() fxevent.Logger {
+			return fxevent.NopLogger
+		}),
 		fx.Supply(booterConfig),
 		fx.Provide(
 			registrar.NewConfigLoader,


### PR DESCRIPTION
This pull request primarily standardizes the suppression of Fx logging across multiple binaries and the test runtime by injecting `fxevent.NopLogger` into all `fx.New` application initializations. Additionally, the development workflow documentation is updated to clarify when controller-local business logic is acceptable.

**Fx Logging Suppression:**

* Added `fx.WithLogger` using `fxevent.NopLogger` to all main application entry points (`cmd/app/main.go`, `cmd/kit/http_route/http_route.go`, `cmd/kit/permission_seeder/permission_seeder.go`, `cmd/kit/rdbms_seeder/rdbms_seeder.go`, `cmd/template/template.go`) to suppress default Fx log output. [[1]](diffhunk://#diff-1f7127b0619adb22616a538989355f8d1887da5cb351a04dec98ab31a7fecbbfR25-R27) [[2]](diffhunk://#diff-13a641078ee1b14b8fd0257e876dfb0e2cf7eccf03ae364631b0f6164d5a44d4R11-R18) [[3]](diffhunk://#diff-d1f81601e5e73a61de57c33e493da34a8913421d84ccbd8b38b75c80a0f25b47R140-R142) [[4]](diffhunk://#diff-8cd68eb2ef4398acf3727092a907071f254a93ddc4785c67ee1d46183f8bafbfR20-R22) [[5]](diffhunk://#diff-23a5445fbb8bbe82fa13e8a9c5fb7ddb47596e3b45ad9bf00ba89cb6224a4b83R8-R15)
* Updated imports to include `go.uber.org/fx/fxevent` where necessary for the new logger. [[1]](diffhunk://#diff-1f7127b0619adb22616a538989355f8d1887da5cb351a04dec98ab31a7fecbbfR13) [[2]](diffhunk://#diff-13a641078ee1b14b8fd0257e876dfb0e2cf7eccf03ae364631b0f6164d5a44d4R11-R18) [[3]](diffhunk://#diff-d1f81601e5e73a61de57c33e493da34a8913421d84ccbd8b38b75c80a0f25b47R12) [[4]](diffhunk://#diff-8cd68eb2ef4398acf3727092a907071f254a93ddc4785c67ee1d46183f8bafbfR11) [[5]](diffhunk://#diff-23a5445fbb8bbe82fa13e8a9c5fb7ddb47596e3b45ad9bf00ba89cb6224a4b83R8-R15) [[6]](diffhunk://#diff-a21941ffa1b195e6ba95325ba2513f6f55293d47989ebecb81ddffa0ccf9dc2fR23)
* Applied the same logging suppression in the test runtime (`internal/test/runtime/runtime.go`) by injecting `fxevent.NopLogger` into `fxtest.New`.

**Documentation Update:**

* Clarified in `AGENTS.md` that controllers may keep business logic locally if it is single-interface-only and meets the Single-Interface Scope/KISS override, instead of always requiring delegation to `internal/pkg/`.