### PR TITLE
Add API endpoint creation skill and consolidate documentation

### DIFF
--- a/.agents/skills/create-api-endpoint/SKILL.md
+++ b/.agents/skills/create-api-endpoint/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: create-api-endpoint
+description: Build or modify API endpoints in this go-backend-framework repository. Use when adding controller files, request/response DTOs, Swagger annotations, canonical error messages, logging, internal/pkg business logic, routes, permissions, seed data, and controller tests for a new or changed API.
+---
+
+# Create API Endpoint
+
+## Goal
+
+Create repository-standard API endpoints with thin HTTP controllers, reusable business logic, synchronized authorization presets, accurate Swagger contracts, and tests for every reachable response path.
+
+## Before Editing
+
+1. Read the root `AGENTS.md`, `.github/copilot-instructions.md` if present, and every `.github/instructions/**/*.instructions.md` file whose `applyTo` matches the files you will touch.
+2. Inspect nearby files before choosing names or patterns:
+   - Controllers: `internal/http/controller/<area>/**`
+   - Routes: `internal/http/route/**`
+   - Business logic: `internal/pkg/<domain>/**`
+   - Error responses: `internal/http/response/error_message.go`
+   - Permissions: `cmd/kit/permission_seeder/permission_seeder.go` and `internal/test/fake/permission.go`
+   - Tests: matching `internal/http/controller/**/*_test.go`
+3. Prefer extending the closest existing area. Create a new area only when the API does not fit an existing controller/route/domain package.
+4. Keep paths in kebab case, Go package names lowercase without underscores, struct names singular PascalCase, and `Id` casing for identifiers.
+
+## Endpoint Workflow
+
+1. Define the API contract:
+   - HTTP method, path, auth requirements, request body/query/path params, response data, and all reachable errors.
+   - Decide whether the route is public, authenticated only, or protected by admin Casbin authorization.
+   - Use existing canonical errors where possible before adding new messages.
+
+2. Implement or extend `internal/pkg/<domain>` first when the behavior is reusable or shared:
+   - Keep functions framework-agnostic; do not import Gin or HTTP response packages.
+   - Accept `*gorm.DB` when database work is needed, matching existing helpers.
+   - Match existing query shape in that package: preload choices, ordering, pagination, and error wrapping.
+   - Wrap multiple writes in a transaction in the business layer when they must succeed together.
+   - Add colocated unit tests where the logic has meaningful branches.
+
+3. Create or update controller files under `internal/http/controller/<area>/`:
+   - Use `<feature>_<action>.go`, for example `user_register.go` or `permission_create.go`.
+   - Put request structs near the handler that binds them unless the local package already centralizes DTOs.
+   - Put response data structs in `shared.go` when reused; otherwise keep them near the handler.
+   - Use `binding` tags for Gin input validation and `json`, `mapstructure`, `validate`, and `format` tags on response DTOs following nearby examples.
+   - Controllers should validate input, call `internal/pkg`, map errors to response messages, log, and format output.
+
+4. Handle requests and responses consistently:
+   - Body input: `c.ShouldBindJSON(reqBody)`.
+   - Query input: `c.ShouldBindQuery(reqQuery)`.
+   - Path params: bind or parse explicitly, and return `response.RequestValidationFailed` or `response.BadRequest` according to nearby controller behavior.
+   - Validation failure pattern:
+
+```go
+errResp := response.NewErrorResponse(response.RequestValidationFailed, errors.WithStack(err), response.MakeValidationErrorContext(err))
+logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
+return
+```
+
+- Success pattern:
+
+```go
+c.JSON(http.StatusOK, response.NewResponse(data))
+```
+
+5. Log every error response:
+   - Start handlers with `logger := deps.Logger()` when the handler can return errors.
+   - Use `logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)` for expected request/business failures.
+   - Use `logger.Error(...)` only for truly unexpected server-side failures if nearby code distinguishes them.
+   - Do not log sensitive values or expose stack traces through user-facing messages.
+
+6. Add canonical error messages only when needed:
+   - Define message constants exclusively in `internal/http/response/error_message.go`.
+   - Add a unique `<status>-<sequence>` entry to `MessageToCode`.
+   - Keep the map grouped by status and update `internal/http/response/error_message_test.go`.
+   - Swagger must list only the messages and status codes the handler can actually return.
+
+7. Add Swagger annotations above the handler:
+   - Include `// @tags`, `// @accept json` when JSON input is accepted, and `// @produce json`.
+   - Use placeholder descriptions as `" "` in every `// @param`.
+   - Include `X-XSRF-TOKEN` for state-changing routes that require CSRF.
+   - Include `Authorization` for authenticated/protected routes.
+   - Use actual DTO names in request and response annotations.
+   - Keep route annotations aligned with runtime path and method, for example `// @router /api/admin/user-role [put]`.
+   - After changing annotations, run `make swagger` unless the user explicitly asks to skip it.
+
+8. Wire routes:
+   - For an existing router, update `internal/http/route/<area>/api_route.go`.
+   - For a new router, create it so it implements `route.Router`, then append it in `internal/http/route/api_route.go`.
+   - Public routes usually live under a specific router group such as `api/user`.
+   - Admin/protected routes should use `middleware.Authenticate()` and `middleware.Authorize()` consistently with `internal/http/route/admin/api_route.go`.
+
+9. Add permissions for protected admin capabilities:
+   - Add permission names and `p` Casbin rules to `cmd/kit/permission_seeder/permission_seeder.go`.
+   - Mirror the same permissions and rules in `internal/test/fake/permission.go`.
+   - Match route paths exactly as Casbin sees them, including `:id` path params and uppercase HTTP methods.
+   - If the admin fixture flow changes, update `internal/test/fixture/domain/permission.go` or `internal/test/fixture/scenario/admin_api.go`.
+   - If a new mock service is introduced, register an empty instance in `internal/test/runtime/runtime.go:emptyMockedServices()`.
+
+10. Write controller tests alongside the handler:
+
+- Use the high-level `internal/test` runtime and fixture abstractions instead of rebuilding app wiring by hand.
+- Inspect `internal/test/test.go` and `internal/test/runtime/runtime.go`, then choose the smallest available runtime constructor or `RuntimeOptions` setup that matches the endpoint dependencies such as HTTP routing, authentication, RDBMS migrations, ClickHouse migrations, Redis, or mocked services.
+- Reuse existing runtime fields and fixture/scenario helpers from `internal/test/fixture/**` before adding new test wiring.
+- Cover success, validation failure, auth failure, authorization failure, business errors, and server errors when reachable.
+- Public mutating routes should include CSRF mismatch tests when middleware applies.
+- Protected routes should test missing/wrong token returns `Unauthorized` and insufficient permission returns `Forbidden`.
+- Decode `response.Response` data into the controller response DTO and assert important fields.
+- Decode failures into `response.ErrorResponse` and assert HTTP status, `Message`, `Code`, and validation `Context` when present.
+
+11. Format and validate:
+
+- Run `gofmt`/`goimports` on changed Go files.
+- Run targeted `go test` for touched packages; broaden to `make test args=./...` or `go test ./...` when risk is wider.
+- Run `make swagger` after annotation changes.
+- Run `make linter` when the change touches shared behavior or before final handoff if time allows.
+
+## File Checklist
+
+Use this as a scoped checklist; not every endpoint needs every file.
+
+- `internal/pkg/<domain>/*.go`: business logic and data access helpers.
+- `internal/pkg/<domain>/*_test.go`: unit tests for reusable logic.
+- `internal/http/controller/<area>/<feature>_<action>.go`: handler, request DTO, local response DTO if not shared.
+- `internal/http/controller/<area>/shared.go`: reusable response data and `Fill` methods.
+- `internal/http/controller/<area>/<feature>_<action>_test.go`: controller/integration tests.
+- `internal/http/route/<area>/api_route.go`: route registration.
+- `internal/http/route/api_route.go`: only when adding a new router.
+- `internal/http/response/error_message.go` and `error_message_test.go`: only when adding canonical errors.
+- `cmd/kit/permission_seeder/permission_seeder.go`: runtime admin permission seeds.
+- `internal/test/fake/permission.go`: mirrored test permission preset.
+- `internal/test/fixture/**`: only when fixture/scenario setup must change.
+- `docs/*`: regenerated Swagger output after annotation changes.
+
+## Example Prompts
+
+```text
+$create-api-endpoint Add an admin GET /api/admin/audit-log endpoint with pagination, permission audit-log-read, Swagger docs, and controller tests.
+```
+
+```text
+$create-api-endpoint Add POST /api/user/profile that validates JSON input, delegates profile updates to internal/pkg/user, returns a ProfileData response, and covers validation/auth/business errors in tests.
+```

--- a/.agents/skills/create-api-endpoint/agents/openai.yaml
+++ b/.agents/skills/create-api-endpoint/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Create API Endpoint"
+  short_description: "Build repo-standard API endpoints"
+  default_prompt: "Use this skill to add or modify an API endpoint in go-backend-framework following the repository workflow."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,10 +55,9 @@ This document guides AI agents and contributors working in this repository. It d
 - Keep package names lowercase with no underscores; prefer descriptive names (`internal/http/controller/user`).
 - Use natural exported identifiers (e.g., `UserLoginRequest`). For camelCase names containing "id", spell it as `Id` (e.g., `userId`).
 - Avoid import aliases unless required for conflict resolution or clarity; rely on the default import name whenever possible.
-- Reuse established helper patterns (e.g., response builders in `internal/http/response`) rather than handcrafting JSON payloads.
+- Reuse established helper patterns rather than handcrafting project-standard behavior.
 - Respect the `jsoniter` build tag where the Makefile enables it.
 - Follow directory-local conventions and keep reusable code in `internal/pkg/`; leave HTTP wiring and other application layers under `internal/`.
-- API route paths must use kebab case (e.g., `pet-store`).
 - Struct names: singular, PascalCase (e.g., `User`, `SchedulerJob`); use another casing only when a schema or user directive explicitly requires it.
 - Table tags: let GORM infer plural table names; only add a `TableName()` override when migrations already created a non-standard name (e.g., `AuditLog` mapping to `"audit_logs"`).
 - Slice fields for relations: use plural names for collections (e.g., `Roles []Role`, `Permissions []Permission`).
@@ -68,9 +67,6 @@ This document guides AI agents and contributors working in this repository. It d
 - Packages: lower-case with no underscores. Files use `snake_case.go` only when it clarifies multiword names already used in the codebase.
 - If a directory name includes underscores for readability (e.g., `user_activity`), keep the Go package name lower-case without underscores and import with an explicit alias only when needed.
 - Follow the naming/style conventions of files in the same directory before introducing new patterns.
-- Helper/query patterns: when adding or modifying helpers, match the existing query shape in that file/package (ordering, preload use, error wrapping). Keep helpers minimal—do not add joins/preloads or extra queries unless the file already does or the requirement demands it.
-- Swagger `// @param` comments must keep the description placeholder as `" "` (do not insert real tokens like `"id"`).
-- Keep Swagger annotations aligned with actual runtime responses; if a handler logs an error instead of returning it, remove the unused error entry from Swagger.
 - When a foreign key guarantees a required parent (e.g., `User` on `UserPermission`), do not add nil-guards before using the preloaded relation.
 
 ### Example: indentation must use tabs
@@ -90,34 +86,18 @@ func main() {
 }
 ```
 
-## Error Responses
-- Define canonical error messages and codes exclusively in `internal/http/response/error_message.go`.
-- Message constants describe user-facing text. Update `MessageToCode` with a unique `<status>-<sequence>` string (e.g., `400-001`).
-- Organize the map by HTTP status headers (`// 400`, `// 401`, etc.) so related errors stay grouped.
-- Ensure handlers return responses whose status aligns with the declared message and add corresponding tests when introducing new errors.
+## API Endpoint Workflow
+When adding or modifying API endpoints, invoke and follow `$create-api-endpoint` from `.agents/skills/create-api-endpoint/SKILL.md`. That skill is the source of truth for controller files, `internal/pkg` business logic, routes, permissions, Swagger contracts, canonical HTTP errors, logging, and controller tests.
 
-## Development Workflow
-When adding a new API endpoint:
-1. Extend or create handler files under `internal/http/controller/<area>` (for example, `internal/http/controller/user/user_register.go`). Follow the existing `<feature>_<action>.go` naming and add matching `*_test.go` coverage.
-2. **REQUIRED**: Implement or extend business logic in `internal/pkg/<domain>` (e.g., `internal/pkg/user`, `internal/pkg/permission`) BEFORE writing controller code by default. Controllers MUST delegate to `internal/pkg/` for shared or reusable business logic. A controller MAY keep single-interface-only flow locally when the Single-Interface Scope/KISS override applies. Keep helpers reusable and include unit tests where practical.
-3. Wire routes in the corresponding router under `internal/http/route/<area>/api_route.go`, ensuring it implements `route.Router` and guards handlers with middleware as needed.
-4. If you introduce a brand-new router, register it in `internal/http/route/api_route.go` by appending it to the `routers` slice so it participates in `AttachRoutes`.
-5. For admin/protected capabilities, synchronise seeds between runtime and tests: update `cmd/kit/permission_seeder/permission_seeder.go` and mirror the same permission preset in `internal/test/fake/permission.go`; adjust `internal/test/fixture/domain/permission.go` or `internal/test/fixture/scenario/admin_api.go` when the admin fixture flow changes.
-6. Whenever you introduce a new mock service (gomock or hand-written), also register an empty instance in `internal/test/runtime/runtime.go:emptyMockedServices()` so the test harness has placeholders for injected services.
-
-General guidance:
+## Development Guidelines
 - Keep changes minimal and localized; avoid unrelated refactors.
 - Favor composition over duplication; reuse helpers under `internal/pkg/` and existing shared utilities.
-- Update Swagger comments whenever API shapes change, then run `make swagger`.
-- Wrap work in a transaction only when multiple insert/update/delete statements need to succeed together.
 
 ## Testing Guidelines
 - Test framework: standard `testing`; `testify` is available for assertions.
 - Location: place `*_test.go` files alongside the code they cover; prefer table-driven tests or testify suites.
-- Bootstrapping: leverage `internal/test/runtime` and `internal/test/fixture/*` helpers for environment loading, migrations, HTTP handlers, seeded users, and scenario setup instead of reimplementing test wiring.
-- Mock services: when introducing a new mock service, also register it in `internal/test/runtime/runtime.go` within `emptyMockedServices` so the test harness initializes it.
 - Migrations: run required migrations first (e.g., `make sqlite-migration args=up`). Tests expect `.env.test` to provide DSNs and secrets.
-- Coverage: exercise both success and failure paths. **REQUIRED**: Test all possible return values from controllers (success, validation failures, auth failures, business errors). Reference existing patterns in `internal/http/controller/**/*_test.go`. Document skipped integration tests in PR descriptions. Add controller/service tests whenever adding new endpoints.
+- Coverage: exercise both success and failure paths. Document skipped integration tests in PR descriptions.
 
 ## Migrations
 - Use Make targets with environment loaded from `.env`: `make mysql-migration args="up"`, `make pgsql-migration args="up"`, `make sqlite-migration args="up"`, or `make clickhouse-migration args="up"`.


### PR DESCRIPTION
This pull request introduces a new repository skill, `$create-api-endpoint`, and updates the main contributor guidelines to centralize and clarify the API endpoint development workflow. The changes move detailed instructions for building and modifying API endpoints into a dedicated skill file, streamline the main `AGENTS.md` document, and update interface metadata for agent use.

**Major improvements include:**

**1. New API Endpoint Skill and Documentation**
- Added `.agents/skills/create-api-endpoint/SKILL.md`, a comprehensive guide detailing the step-by-step process for creating and updating API endpoints, including controller patterns, business logic, permissions, Swagger docs, error handling, logging, and testing. This serves as the canonical workflow for contributors and AI agents.
- Added `.agents/skills/create-api-endpoint/agents/openai.yaml` to provide agent interface metadata for the new skill, including display name, description, and default prompt.

**2. Centralization and Streamlining of Guidelines in `AGENTS.md`**
- Replaced the detailed API endpoint workflow and error response sections in `AGENTS.md` with a reference to the new `$create-api-endpoint` skill, making that skill the source of truth for endpoint development.
- Updated development and testing guidelines to remove redundant or now-centralized instructions, focusing on general best practices and test coverage expectations.

**3. Clarification and Simplification of Naming and Helper Patterns**
- Simplified language around helper and response patterns, removing references to specific files and focusing on reusing established project-standard behavior.
- Removed prescriptive details about Swagger annotation formatting and helper/query patterns, deferring those specifics to the new skill documentation.

These changes improve maintainability by consolidating API endpoint development practices into a single, easily updatable skill file, and by simplifying the main contributor documentation.

- New API endpoint skill and documentation: `.agents/skills/create-api-endpoint/SKILL.md` [[1]](diffhunk://#diff-3c982e70fc10c4098e32c2ec6eea3c3f6f039f59a6f878783fcde8807cee6277R1-R142) `.agents/skills/create-api-endpoint/agents/openai.yaml` [[2]](diffhunk://#diff-41931f3155d3207fb9a80752f04512aa1dfd79a0dc1cef87d3c3ec28af3e5673R1-R4)
- Centralization and streamlining of guidelines in `AGENTS.md`
- Clarification and simplification of naming and helper patterns [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L58-L61) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L71-L73)