### PR TITLE
refactor(http): preserve request body for error logging

### DIFF
--- a/internal/http/controller/admin/http_api/http_api_search.go
+++ b/internal/http/controller/admin/http_api/http_api_search.go
@@ -41,7 +41,7 @@ func Search(c *gin.Context) {
 	logger := deps.Logger()
 	if err := c.ShouldBindQuery(queryString); err != nil {
 		errResp := response.NewErrorResponse(response.RequestValidationFailed, errors.WithStack(err), response.MakeValidationErrorContext(err))
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -66,7 +66,7 @@ func Search(c *gin.Context) {
 	httpApis := []model.HttpApi{}
 	if err := paginator.Execute(&httpApis).Error; err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, errors.WithStack(err), nil)
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}

--- a/internal/http/controller/admin/permission/permission_create.go
+++ b/internal/http/controller/admin/permission/permission_create.go
@@ -42,9 +42,9 @@ type PermissionCreateData struct {
 func Create(c *gin.Context) {
 	reqBody := new(PermissionCreateRequest)
 	logger := deps.Logger()
-	if err := c.ShouldBindJSON(reqBody); err != nil {
+	if err := c.ShouldBindBodyWithJSON(reqBody); err != nil {
 		errResp := response.NewErrorResponse(response.RequestValidationFailed, errors.WithStack(err), response.MakeValidationErrorContext(err))
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -71,7 +71,7 @@ func Create(c *gin.Context) {
 	})
 	if err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, errors.WithStack(err), nil)
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -79,7 +79,7 @@ func Create(c *gin.Context) {
 	enforcer := deps.CasbinEnforcer()
 	if err := enforcer.LoadPolicy(); err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, errors.WithStack(err), nil)
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}

--- a/internal/http/controller/admin/permission/permission_delete.go
+++ b/internal/http/controller/admin/permission/permission_delete.go
@@ -34,9 +34,9 @@ type PermissionDeleteRequest struct {
 func Delete(c *gin.Context) {
 	reqBody := new(PermissionDeleteRequest)
 	logger := deps.Logger()
-	if err := c.ShouldBindJSON(reqBody); err != nil {
+	if err := c.ShouldBindBodyWithJSON(reqBody); err != nil {
 		errResp := response.NewErrorResponse(response.RequestValidationFailed, errors.WithStack(err), response.MakeValidationErrorContext(err))
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -44,7 +44,7 @@ func Delete(c *gin.Context) {
 	permissions, err := permission.GetMany(database.NewTx(), "id IN ?", reqBody.Ids)
 	if err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, errors.WithStack(err), nil)
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -69,7 +69,7 @@ func Delete(c *gin.Context) {
 	})
 	if err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, errors.WithStack(err), nil)
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -77,7 +77,7 @@ func Delete(c *gin.Context) {
 	enforcer := deps.CasbinEnforcer()
 	if err := enforcer.LoadPolicy(); err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, errors.WithStack(err), nil)
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}

--- a/internal/http/controller/admin/permission/permission_get.go
+++ b/internal/http/controller/admin/permission/permission_get.go
@@ -31,7 +31,7 @@ func Get(c *gin.Context) {
 	logger := deps.Logger()
 	if err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, err, nil)
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -39,7 +39,7 @@ func Get(c *gin.Context) {
 	casbinRules, err := permission.GetCasbinRules(database.NewTx(), "ptype = ? AND v0 = ?", "p", p.Name)
 	if err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, err, nil)
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}

--- a/internal/http/controller/admin/permission/permission_reload.go
+++ b/internal/http/controller/admin/permission/permission_reload.go
@@ -25,7 +25,7 @@ func Reload(c *gin.Context) {
 	if err := enforcer.LoadPolicy(); err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, errors.WithStack(err), nil)
 		logger := deps.Logger()
-		logger.Warn(response.BadRequest, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(response.BadRequest, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}

--- a/internal/http/controller/admin/permission/permission_search.go
+++ b/internal/http/controller/admin/permission/permission_search.go
@@ -41,7 +41,7 @@ func Search(c *gin.Context) {
 	logger := deps.Logger()
 	if err := c.ShouldBindQuery(queryString); err != nil {
 		errResp := response.NewErrorResponse(response.RequestValidationFailed, errors.WithStack(err), response.MakeValidationErrorContext(err))
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -64,7 +64,7 @@ func Search(c *gin.Context) {
 		Execute(&permissions)
 	if err := db.Error; err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, errors.WithStack(err), nil)
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}

--- a/internal/http/controller/admin/permission/permission_update.go
+++ b/internal/http/controller/admin/permission/permission_update.go
@@ -45,9 +45,9 @@ type PermissionUpdateData struct {
 func Update(c *gin.Context) {
 	reqBody := new(PermissionUpdateRequest)
 	logger := deps.Logger()
-	if err := c.ShouldBindJSON(reqBody); err != nil {
+	if err := c.ShouldBindBodyWithJSON(reqBody); err != nil {
 		errResp := response.NewErrorResponse(response.RequestValidationFailed, errors.WithStack(err), response.MakeValidationErrorContext(err))
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -94,7 +94,7 @@ func Update(c *gin.Context) {
 	})
 	if err != nil && !errors.Is(err, sql.ErrTxDone) {
 		errResp := response.NewErrorResponse(response.BadRequest, errors.WithStack(err), nil)
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -102,7 +102,7 @@ func Update(c *gin.Context) {
 	enforcer := deps.CasbinEnforcer()
 	if err := enforcer.LoadPolicy(); err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, errors.WithStack(err), nil)
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -110,7 +110,7 @@ func Update(c *gin.Context) {
 	p, err := permission.Get(database.NewTx(), "id = ?", c.Param("id"))
 	if err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, err, nil)
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}

--- a/internal/http/controller/admin/permission/role_create.go
+++ b/internal/http/controller/admin/permission/role_create.go
@@ -34,9 +34,9 @@ type RoleCreateRequest struct {
 func CreateRole(c *gin.Context) {
 	reqBody := new(RoleCreateRequest)
 	logger := deps.Logger()
-	if err := c.ShouldBindJSON(reqBody); err != nil {
+	if err := c.ShouldBindBodyWithJSON(reqBody); err != nil {
 		errResp := response.NewErrorResponse(response.RequestValidationFailed, errors.WithStack(err), response.MakeValidationErrorContext(err))
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -63,7 +63,7 @@ func CreateRole(c *gin.Context) {
 	})
 	if err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, errors.WithStack(err), nil)
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -71,7 +71,7 @@ func CreateRole(c *gin.Context) {
 	role, err = permission.GetRole(database.NewTx("Permissions"), "id = ?", role.Id)
 	if err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, errors.WithStack(err), nil)
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}

--- a/internal/http/controller/admin/permission/role_delete.go
+++ b/internal/http/controller/admin/permission/role_delete.go
@@ -32,9 +32,9 @@ type RoleDeleteRequest struct {
 func DeleteRoles(c *gin.Context) {
 	reqBody := new(RoleDeleteRequest)
 	logger := deps.Logger()
-	if err := c.ShouldBindJSON(reqBody); err != nil {
+	if err := c.ShouldBindBodyWithJSON(reqBody); err != nil {
 		errResp := response.NewErrorResponse(response.RequestValidationFailed, errors.WithStack(err), response.MakeValidationErrorContext(err))
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -42,7 +42,7 @@ func DeleteRoles(c *gin.Context) {
 	roles, err := permission.GetRoles(database.NewTx("Permissions", "Users"), "id IN ?", reqBody.Ids)
 	if err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, errors.WithStack(err), nil)
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -81,7 +81,7 @@ func DeleteRoles(c *gin.Context) {
 	})
 	if err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, errors.WithStack(err), nil)
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -89,7 +89,7 @@ func DeleteRoles(c *gin.Context) {
 	enforcer := deps.CasbinEnforcer()
 	if err := enforcer.LoadPolicy(); err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, errors.WithStack(err), nil)
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}

--- a/internal/http/controller/admin/permission/role_search.go
+++ b/internal/http/controller/admin/permission/role_search.go
@@ -42,7 +42,7 @@ func SearchRoles(c *gin.Context) {
 	logger := deps.Logger()
 	if err := c.ShouldBindQuery(queryString); err != nil {
 		errResp := response.NewErrorResponse(response.RequestValidationFailed, errors.WithStack(err), response.MakeValidationErrorContext(err))
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -68,7 +68,7 @@ func SearchRoles(c *gin.Context) {
 		Execute(&roles)
 	if err := db.Error; err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, errors.WithStack(err), nil)
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}

--- a/internal/http/controller/admin/permission/role_update.go
+++ b/internal/http/controller/admin/permission/role_update.go
@@ -41,9 +41,9 @@ type RoleUpdateRequest struct {
 func UpdateRole(c *gin.Context) {
 	reqBody := new(RoleUpdateRequest)
 	logger := deps.Logger()
-	if err := c.ShouldBindJSON(reqBody); err != nil {
+	if err := c.ShouldBindBodyWithJSON(reqBody); err != nil {
 		errResp := response.NewErrorResponse(response.RequestValidationFailed, errors.WithStack(err), response.MakeValidationErrorContext(err))
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -116,7 +116,7 @@ func UpdateRole(c *gin.Context) {
 	})
 	if err != nil && !errors.Is(err, sql.ErrTxDone) {
 		errResp := response.NewErrorResponse(response.BadRequest, errors.WithStack(err), nil)
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -124,7 +124,7 @@ func UpdateRole(c *gin.Context) {
 	enforcer := deps.CasbinEnforcer()
 	if err := enforcer.LoadPolicy(); err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, errors.WithStack(err), nil)
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -132,7 +132,7 @@ func UpdateRole(c *gin.Context) {
 	role, err := permission.GetRole(database.NewTx("Permissions"), "id = ?", c.Param("id"))
 	if err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, err, nil)
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}

--- a/internal/http/controller/admin/user/user_role_update.go
+++ b/internal/http/controller/admin/user/user_role_update.go
@@ -37,9 +37,9 @@ type UserRoleUpdateRequest struct {
 func UpdateUserRole(c *gin.Context) {
 	reqBody := new(UserRoleUpdateRequest)
 	logger := deps.Logger()
-	if err := c.ShouldBindJSON(reqBody); err != nil {
+	if err := c.ShouldBindBodyWithJSON(reqBody); err != nil {
 		errResp := response.NewErrorResponse(response.RequestValidationFailed, errors.WithStack(err), response.MakeValidationErrorContext(err))
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -47,7 +47,7 @@ func UpdateUserRole(c *gin.Context) {
 	roles, err := permission.GetRoles(database.NewTx("Permissions"), "id IN ?", reqBody.RoleIds)
 	if err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, errors.WithStack(err), nil)
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -58,7 +58,7 @@ func UpdateUserRole(c *gin.Context) {
 	}
 	if len(permissions) != len(lo.Union(permissions)) {
 		errResp := response.NewErrorResponse(response.PermissionIsRepeat, errors.WithStack(err), nil)
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -101,7 +101,7 @@ func UpdateUserRole(c *gin.Context) {
 	})
 	if err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, errors.WithStack(err), nil)
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -109,7 +109,7 @@ func UpdateUserRole(c *gin.Context) {
 	enforcer := deps.CasbinEnforcer()
 	if err := enforcer.LoadPolicy(); err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, errors.WithStack(err), nil)
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -117,7 +117,7 @@ func UpdateUserRole(c *gin.Context) {
 	u, err := user.Get(database.NewTx("Roles"), "id = ?", reqBody.UserId)
 	if err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, errors.WithStack(err), nil)
-		logger.Warn(errResp.Message, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(errResp.Message, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}

--- a/internal/http/controller/user/user_login.go
+++ b/internal/http/controller/user/user_login.go
@@ -33,9 +33,9 @@ type UserLoginRequest struct {
 func Login(c *gin.Context) {
 	logger := deps.Logger()
 	reqBody := new(UserLoginRequest)
-	if err := c.ShouldBindJSON(reqBody); err != nil {
+	if err := c.ShouldBindBodyWithJSON(reqBody); err != nil {
 		errResp := response.NewErrorResponse(response.RequestValidationFailed, errors.WithStack(err), response.MakeValidationErrorContext(err))
-		logger.Warn(response.RequestValidationFailed, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(response.RequestValidationFailed, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -43,13 +43,13 @@ func Login(c *gin.Context) {
 	u, err := user.Get(database.NewTx(), "email = ?", reqBody.Email)
 	if err != nil {
 		errResp := response.NewErrorResponse(response.EmailIsWrong, err, nil)
-		logger.Warn(response.EmailIsWrong, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(response.EmailIsWrong, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
 	if !argon2.VerifyArgon2IdHash(reqBody.Password, u.Password) {
 		errResp := response.NewErrorResponse(response.PasswordIsWrong, errors.New(response.PasswordIsWrong), nil)
-		logger.Warn(response.PasswordIsWrong, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(response.PasswordIsWrong, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -61,7 +61,7 @@ func Login(c *gin.Context) {
 	}
 	if err := encoder.Encode(userQuery, values); err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, errors.WithStack(err), nil)
-		logger.Warn(response.BadRequest, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(response.BadRequest, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -70,7 +70,7 @@ func Login(c *gin.Context) {
 	accessToken, err := authenticator.IssueAccessToken(values.Encode())
 	if err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, errors.WithStack(err), nil)
-		logger.Warn(response.BadRequest, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(response.BadRequest, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}

--- a/internal/http/controller/user/user_me.go
+++ b/internal/http/controller/user/user_me.go
@@ -24,7 +24,7 @@ func Me(c *gin.Context) {
 	if err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, err, nil)
 		logger := deps.Logger()
-		logger.Warn(response.BadRequest, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(response.BadRequest, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}

--- a/internal/http/controller/user/user_register.go
+++ b/internal/http/controller/user/user_register.go
@@ -33,9 +33,9 @@ type UserRegisterRequest struct {
 func Register(c *gin.Context) {
 	logger := deps.Logger()
 	reqBody := new(UserRegisterRequest)
-	if err := c.ShouldBindJSON(reqBody); err != nil {
+	if err := c.ShouldBindBodyWithJSON(reqBody); err != nil {
 		errResp := response.NewErrorResponse(response.RequestValidationFailed, errors.WithStack(err), response.MakeValidationErrorContext(err))
-		logger.Warn(response.RequestValidationFailed, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(response.RequestValidationFailed, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -47,7 +47,7 @@ func Register(c *gin.Context) {
 	}
 	if err := user.Create(database.NewTx(), u); err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, err, nil)
-		logger.Warn(response.BadRequest, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(response.BadRequest, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -56,7 +56,7 @@ func Register(c *gin.Context) {
 	accessToken, err := authenticator.IssueAccessToken(fmt.Sprintf("%v", u.Id))
 	if err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, errors.WithStack(err), nil)
-		logger.Warn(response.BadRequest, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(response.BadRequest, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}

--- a/internal/http/controller/user/user_update.go
+++ b/internal/http/controller/user/user_update.go
@@ -31,9 +31,9 @@ type UserUpdateRequest struct {
 func Update(c *gin.Context) {
 	logger := deps.Logger()
 	reqBody := new(UserUpdateRequest)
-	if err := c.ShouldBindJSON(reqBody); err != nil {
+	if err := c.ShouldBindBodyWithJSON(reqBody); err != nil {
 		errResp := response.NewErrorResponse(response.RequestValidationFailed, errors.WithStack(err), response.MakeValidationErrorContext(err))
-		logger.Warn(response.RequestValidationFailed, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(response.RequestValidationFailed, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -42,7 +42,7 @@ func Update(c *gin.Context) {
 	_, err := user.Update(database.NewTx(), c.GetUint("user_id"), values)
 	if err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, err, nil)
-		logger.Warn(response.BadRequest, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(response.BadRequest, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -50,7 +50,7 @@ func Update(c *gin.Context) {
 	u, err := user.Get(database.NewTx(), "id = ?", c.GetUint("user_id"))
 	if err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, err, nil)
-		logger.Warn(response.BadRequest, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(response.BadRequest, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}

--- a/internal/http/controller/user/user_update_password.go
+++ b/internal/http/controller/user/user_update_password.go
@@ -33,9 +33,9 @@ type UserUpdatePasswordRequest struct {
 func UpdatePassword(c *gin.Context) {
 	logger := deps.Logger()
 	reqBody := new(UserUpdatePasswordRequest)
-	if err := c.ShouldBindJSON(reqBody); err != nil {
+	if err := c.ShouldBindBodyWithJSON(reqBody); err != nil {
 		errResp := response.NewErrorResponse(response.RequestValidationFailed, errors.WithStack(err), response.MakeValidationErrorContext(err))
-		logger.Warn(response.RequestValidationFailed, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(response.RequestValidationFailed, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -43,14 +43,14 @@ func UpdatePassword(c *gin.Context) {
 	u, err := user.Get(database.NewTx(), "id = ?", c.GetUint("user_id"))
 	if err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, err, nil)
-		logger.Warn(response.BadRequest, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(response.BadRequest, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
 
 	if !argon2.VerifyArgon2IdHash(reqBody.CurrentPassword, u.Password) {
 		errResp := response.NewErrorResponse(response.PasswordIsWrong, errors.New(response.PasswordIsWrong), nil)
-		logger.Warn(response.PasswordIsWrong, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(response.PasswordIsWrong, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}
@@ -59,7 +59,7 @@ func UpdatePassword(c *gin.Context) {
 	values := structs.Map(reqBody)
 	if _, err := user.Update(database.NewTx(), c.GetUint("user_id"), values); err != nil {
 		errResp := response.NewErrorResponse(response.BadRequest, err, nil)
-		logger.Warn(response.BadRequest, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(response.BadRequest, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 		return
 	}

--- a/internal/http/middleware/authentication_middleware.go
+++ b/internal/http/middleware/authentication_middleware.go
@@ -21,7 +21,7 @@ func Authenticate() gin.HandlerFunc {
 		authorizationHeader := c.GetHeader("Authorization")
 		if !strings.HasPrefix(authorizationHeader, "Bearer") {
 			errResp := response.NewErrorResponse(response.Unauthorized, errors.New("jwt authentication failed"), nil)
-			logger.Warn(response.Unauthorized, errResp.MakeLogFields(c.Request)...)
+			logger.Warn(response.Unauthorized, errResp.MakeLogFields(c)...)
 			c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 			return
 		}
@@ -30,7 +30,7 @@ func Authenticate() gin.HandlerFunc {
 		subject, err := verifyAccessToken(authenticator, accessTokenString)
 		if err != nil {
 			errResp := response.NewErrorResponse(response.Unauthorized, err, nil)
-			logger.Warn(response.Unauthorized, errResp.MakeLogFields(c.Request)...)
+			logger.Warn(response.Unauthorized, errResp.MakeLogFields(c)...)
 			c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 			return
 		}
@@ -38,7 +38,7 @@ func Authenticate() gin.HandlerFunc {
 		values, err := url.ParseQuery(subject)
 		if err != nil {
 			errResp := response.NewErrorResponse(response.Unauthorized, errors.WithStack(err), nil)
-			logger.Warn(response.Unauthorized, errResp.MakeLogFields(c.Request)...)
+			logger.Warn(response.Unauthorized, errResp.MakeLogFields(c)...)
 			c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 			return
 		}
@@ -47,7 +47,7 @@ func Authenticate() gin.HandlerFunc {
 		userQuery := &user.Query{}
 		if err := decoder.Decode(userQuery, values); err != nil {
 			errResp := response.NewErrorResponse(response.Unauthorized, errors.WithStack(err), nil)
-			logger.Warn(response.Unauthorized, errResp.MakeLogFields(c.Request)...)
+			logger.Warn(response.Unauthorized, errResp.MakeLogFields(c)...)
 			c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 			return
 		}

--- a/internal/http/middleware/authorization_middleware.go
+++ b/internal/http/middleware/authorization_middleware.go
@@ -17,14 +17,14 @@ func Authorize() gin.HandlerFunc {
 		ok, err := enforcer.Enforce(strconv.FormatUint(uint64(userId), 10), c.Request.URL.Path, c.Request.Method)
 		if err != nil {
 			errResp := response.NewErrorResponse(response.Forbidden, errors.WithStack(err), nil)
-			logger.Warn(response.Forbidden, errResp.MakeLogFields(c.Request)...)
+			logger.Warn(response.Forbidden, errResp.MakeLogFields(c)...)
 			c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 			return
 		}
 
 		if !ok {
 			errResp := response.NewErrorResponse(response.Forbidden, errors.New("casbin authorization failed"), nil)
-			logger.Warn(response.Forbidden, errResp.MakeLogFields(c.Request)...)
+			logger.Warn(response.Forbidden, errResp.MakeLogFields(c)...)
 			c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 			return
 		}

--- a/internal/http/middleware/rate_limit_middleware.go
+++ b/internal/http/middleware/rate_limit_middleware.go
@@ -25,7 +25,7 @@ func RateLimit(config config.RateLimitConfig) gin.HandlerFunc {
 			return
 		}
 		errResp := response.NewErrorResponse(response.ServiceUnavailable, errors.New("token bucket is empty"), nil)
-		logger.Error(response.ServiceUnavailable, errResp.MakeLogFields(c.Request)...)
+		logger.Error(response.ServiceUnavailable, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 	}
 }

--- a/internal/http/middleware/recover_middleware.go
+++ b/internal/http/middleware/recover_middleware.go
@@ -33,7 +33,7 @@ func Recover() gin.HandlerFunc {
 			}
 
 			errResp := response.NewErrorResponse(response.InternalServerError, errors.New(fmt.Sprintf("%v", err)), nil)
-			logger.Error(response.InternalServerError, errResp.MakeLogFields(c.Request)...)
+			logger.Error(response.InternalServerError, errResp.MakeLogFields(c)...)
 			if isBrokenPipe {
 				c.Abort()
 			} else {

--- a/internal/http/middleware/verify_csrf_token_middleware.go
+++ b/internal/http/middleware/verify_csrf_token_middleware.go
@@ -27,7 +27,7 @@ func VerifyCsrfToken(config *config.CsrfConfig) gin.HandlerFunc {
 		}
 
 		errResp := response.NewErrorResponse(response.Forbidden, errors.New("csrf token mismatch"), nil)
-		logger.Warn(response.Forbidden, errResp.MakeLogFields(c.Request)...)
+		logger.Warn(response.Forbidden, errResp.MakeLogFields(c)...)
 		c.AbortWithStatusJSON(errResp.StatusCode(), errResp)
 	}
 }

--- a/internal/http/response/error_response.go
+++ b/internal/http/response/error_response.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/chan-jui-huang/go-backend-framework/v3/internal/deps"
 	"github.com/chan-jui-huang/go-backend-package/v2/pkg/stacktrace"
+	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 )
 
@@ -69,16 +70,27 @@ func (er *ErrorResponse) StatusCode() int {
 	return int(code)
 }
 
-func (er *ErrorResponse) MakeLogFields(req *http.Request, fields ...zap.Field) []zap.Field {
-	requestBody, err := io.ReadAll(req.Body)
-	if err != nil {
-		logger := deps.Logger()
-		logger.Error(err.Error())
-		requestBody = nil
+func (er *ErrorResponse) MakeLogFields(c *gin.Context, fields ...zap.Field) []zap.Field {
+	req := c.Request
+
+	var requestBody []byte
+	if bodyValue, ok := c.Get(gin.BodyBytesKey); ok {
+		if bodyBytes, ok := bodyValue.([]byte); ok {
+			requestBody = bodyBytes
+		}
+	} else if req.Body != nil {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			logger := deps.Logger()
+			logger.Error(err.Error())
+		} else {
+			requestBody = body
+		}
 	}
+
 	if requestBody != nil && json.Valid(requestBody) {
 		buffer := bytes.NewBuffer(make([]byte, 0, len(requestBody)))
-		err = json.Compact(buffer, requestBody)
+		err := json.Compact(buffer, requestBody)
 		if err != nil {
 			logger := deps.Logger()
 			logger.Error(err.Error())


### PR DESCRIPTION
Update JSON-bound controllers to use `ShouldBindBodyWithJSON` so the request body stays available after binding. Adjust error logging to read from `gin.Context`, which lets `MakeLogFields` reuse Gins cached body bytes when present. Update controllers and middleware call sites to pass the context through the new logging API.