### PR TITLE
Bump Go toolchain version to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chan-jui-huang/go-backend-framework/v3
 
-go 1.26.0
+go 1.26.4
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.43.0


### PR DESCRIPTION
Updates the module Go version from 1.26.0 to 1.26.4 to keep the project aligned with the current patch release.