### PR TITLE
Enhance request log security with filtering and policy updates

### DIFF
--- a/internal/http/requestlog/filter.go
+++ b/internal/http/requestlog/filter.go
@@ -1,0 +1,236 @@
+package requestlog
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"unicode"
+
+	"github.com/gin-gonic/gin"
+)
+
+const maxBodySize = 1 << 20
+
+var (
+	errBodyTooLarge          = errors.New("request body exceeds logging size limit")
+	errInvalidJSON           = errors.New("request body is not a valid JSON object")
+	errInvalidAllowlistPath  = errors.New("request body allowlist contains an invalid path")
+	errForbiddenAllowlistKey = errors.New("request body allowlist contains a forbidden field")
+	errSensitiveBody         = errors.New("request body contains a forbidden field")
+)
+
+var forbiddenFields = map[string]struct{}{
+	"password":        {},
+	"currentpassword": {},
+	"confirmpassword": {},
+	"token":           {},
+	"accesstoken":     {},
+	"refreshtoken":    {},
+	"authorization":   {},
+	"secret":          {},
+	"clientsecret":    {},
+	"clienttoken":     {},
+	"apikey":          {},
+	"privatekey":      {},
+	"credential":      {},
+	"credentials":     {},
+}
+
+var forbiddenFieldSuffixes = []string{
+	"password",
+	"secret",
+	"token",
+	"authorization",
+	"apikey",
+	"privatekey",
+	"passphrase",
+	"credential",
+	"credentials",
+}
+
+type fieldTree map[string]fieldTree
+
+// Filter returns a compact JSON body containing only fields allowed for the destination.
+func Filter(c *gin.Context, destination Destination) ([]byte, error) {
+	fields, hasPolicy := fieldsFor(c, destination)
+	if hasPolicy && len(fields) == 0 {
+		return nil, nil
+	}
+
+	source, err := decodeBody(c)
+	if err != nil || source == nil {
+		return nil, err
+	}
+
+	if !hasPolicy {
+		if containsForbiddenField(source) {
+			return nil, errSensitiveBody
+		}
+
+		return marshalBody(source)
+	}
+
+	tree, err := compileFieldTree(fields)
+	if err != nil {
+		return nil, err
+	}
+
+	filtered := selectObject(source, tree)
+	if len(filtered) == 0 {
+		return nil, nil
+	}
+	if containsForbiddenField(filtered) {
+		return nil, errForbiddenAllowlistKey
+	}
+
+	return marshalBody(filtered)
+}
+
+func decodeBody(c *gin.Context) (map[string]any, error) {
+	bodyValue, ok := c.Get(gin.BodyBytesKey)
+	if !ok {
+		return nil, nil
+	}
+
+	body, ok := bodyValue.([]byte)
+	if !ok || len(body) == 0 {
+		return nil, nil
+	}
+	if len(body) > maxBodySize {
+		return nil, errBodyTooLarge
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+
+	var source map[string]any
+	if err := decoder.Decode(&source); err != nil {
+		return nil, fmt.Errorf("%w: %v", errInvalidJSON, err)
+	}
+	if source == nil {
+		return nil, errInvalidJSON
+	}
+
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return nil, errInvalidJSON
+	}
+
+	return source, nil
+}
+
+func marshalBody(body map[string]any) ([]byte, error) {
+	result, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request body for logging: %w", err)
+	}
+
+	return result, nil
+}
+
+func compileFieldTree(fields []string) (fieldTree, error) {
+	tree := fieldTree{}
+	for _, field := range fields {
+		parts := strings.Split(field, ".")
+		current := tree
+		for _, part := range parts {
+			if part == "" {
+				return nil, errInvalidAllowlistPath
+			}
+			if isForbiddenField(part) {
+				return nil, fmt.Errorf("%w: %s", errForbiddenAllowlistKey, field)
+			}
+
+			next, ok := current[part]
+			if !ok {
+				next = fieldTree{}
+				current[part] = next
+			}
+			current = next
+		}
+	}
+
+	return tree, nil
+}
+
+func selectObject(source map[string]any, tree fieldTree) map[string]any {
+	result := make(map[string]any, len(tree))
+	for field, children := range tree {
+		value, ok := source[field]
+		if !ok {
+			continue
+		}
+
+		if len(children) == 0 {
+			result[field] = value
+			continue
+		}
+
+		filtered, ok := selectValue(value, children)
+		if ok {
+			result[field] = filtered
+		}
+	}
+
+	return result
+}
+
+func selectValue(value any, tree fieldTree) (any, bool) {
+	switch typedValue := value.(type) {
+	case map[string]any:
+		filtered := selectObject(typedValue, tree)
+		return filtered, len(filtered) > 0
+	case []any:
+		filtered := make([]any, 0, len(typedValue))
+		for _, item := range typedValue {
+			selected, ok := selectValue(item, tree)
+			if ok {
+				filtered = append(filtered, selected)
+			}
+		}
+		return filtered, len(filtered) > 0
+	default:
+		return nil, false
+	}
+}
+
+func containsForbiddenField(value any) bool {
+	switch typedValue := value.(type) {
+	case map[string]any:
+		for field, nestedValue := range typedValue {
+			if isForbiddenField(field) || containsForbiddenField(nestedValue) {
+				return true
+			}
+		}
+	case []any:
+		for _, nestedValue := range typedValue {
+			if containsForbiddenField(nestedValue) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func isForbiddenField(field string) bool {
+	normalized := strings.Map(func(r rune) rune {
+		if r == '_' || r == '-' || unicode.IsSpace(r) {
+			return -1
+		}
+		return unicode.ToLower(r)
+	}, field)
+	if _, ok := forbiddenFields[normalized]; ok {
+		return true
+	}
+	for _, suffix := range forbiddenFieldSuffixes {
+		if strings.HasSuffix(normalized, suffix) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/http/requestlog/filter_test.go
+++ b/internal/http/requestlog/filter_test.go
@@ -1,0 +1,140 @@
+package requestlog
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name        string
+		body        string
+		policy      *Policy
+		destination Destination
+		expected    string
+		expectsErr  bool
+	}{
+		{
+			name:     "default records non-sensitive body",
+			body:     "{\"name\":\"John\",\"email\":\"john@test.com\"}",
+			expected: "{\"name\":\"John\",\"email\":\"john@test.com\"}",
+		},
+		{
+			name:       "default rejects nested sensitive body",
+			body:       "{\"profile\":{\"accessToken\":\"secret\"}}",
+			expectsErr: true,
+		},
+		{
+			name:       "default rejects top-level sensitive body",
+			body:       "{\"email\":\"john@test.com\",\"password\":\"secret\"}",
+			expectsErr: true,
+		},
+		{
+			name:       "default rejects sensitive suffixes",
+			body:       "{\"metadata\":{\"new_password\":\"secret\",\"webhookSecret\":\"secret\",\"id-token\":\"secret\"}}",
+			expectsErr: true,
+		},
+		{
+			name:       "default rejects credential containers",
+			body:       "{\"serviceCredential\":{\"value\":\"secret\"}}",
+			expectsErr: true,
+		},
+		{
+			name:   "empty policy denies malformed body without parsing",
+			body:   "{\"email\":",
+			policy: &Policy{},
+		},
+		{
+			name:     "login policy retains email",
+			body:     "{\"email\":\"john@test.com\",\"password\":\"secret\"}",
+			policy:   &Policy{ErrorLog: []string{"email"}},
+			expected: "{\"email\":\"john@test.com\"}",
+		},
+		{
+			name:     "nested array paths",
+			body:     "{\"items\":[{\"id\":1,\"password\":\"secret\"}]}",
+			policy:   &Policy{ErrorLog: []string{"items.id"}},
+			expected: "{\"items\":[{\"id\":1}]}",
+		},
+		{
+			name:     "nested object paths",
+			body:     "{\"settings\":{\"timezone\":\"Asia/Taipei\",\"api_key\":\"secret\"}}",
+			policy:   &Policy{ErrorLog: []string{"settings.timezone"}},
+			expected: "{\"settings\":{\"timezone\":\"Asia/Taipei\"}}",
+		},
+		{
+			name:       "forbidden allowlist field",
+			body:       "{\"Password\":\"secret\"}",
+			policy:     &Policy{ErrorLog: []string{"Password"}},
+			expectsErr: true,
+		},
+		{
+			name:       "forbidden field below allowed parent",
+			body:       "{\"settings\":{\"apiKey\":\"secret\"}}",
+			policy:     &Policy{ErrorLog: []string{"settings"}},
+			expectsErr: true,
+		},
+		{
+			name:       "invalid allowlist path",
+			body:       "{\"settings\":{\"timezone\":\"Asia/Taipei\"}}",
+			policy:     &Policy{ErrorLog: []string{"settings..timezone"}},
+			expectsErr: true,
+		},
+		{
+			name:       "invalid JSON",
+			body:       "{\"email\":",
+			policy:     &Policy{ErrorLog: []string{"email"}},
+			expectsErr: true,
+		},
+		{
+			name:       "non-object JSON",
+			body:       "[1,2,3]",
+			policy:     &Policy{ErrorLog: []string{"email"}},
+			expectsErr: true,
+		},
+		{
+			name:       "body too large",
+			body:       strings.Repeat("a", maxBodySize+1),
+			policy:     &Policy{ErrorLog: []string{"email"}},
+			expectsErr: true,
+		},
+		{
+			name:        "separate operation record policy",
+			body:        "{\"email\":\"john@test.com\",\"name\":\"John\"}",
+			policy:      &Policy{ErrorLog: []string{"email"}, OperationRecord: []string{"name"}},
+			destination: OperationRecord,
+			expected:    "{\"name\":\"John\"}",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Set(gin.BodyBytesKey, []byte(test.body))
+			if test.policy != nil {
+				WithPolicy(*test.policy)(c)
+			}
+
+			originalBody := append([]byte(nil), c.MustGet(gin.BodyBytesKey).([]byte)...)
+			result, err := Filter(c, test.destination)
+			if test.expectsErr {
+				require.Error(t, err)
+				require.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				if test.expected == "" {
+					require.Empty(t, result)
+				} else {
+					require.JSONEq(t, test.expected, string(result))
+				}
+			}
+			require.Equal(t, originalBody, c.MustGet(gin.BodyBytesKey))
+		})
+	}
+}

--- a/internal/http/requestlog/middleware.go
+++ b/internal/http/requestlog/middleware.go
@@ -1,0 +1,14 @@
+package requestlog
+
+import "github.com/gin-gonic/gin"
+
+// WithPolicy stores an immutable copy of a route's request logging policy.
+func WithPolicy(policy Policy) gin.HandlerFunc {
+	policy.ErrorLog = append([]string(nil), policy.ErrorLog...)
+	policy.OperationRecord = append([]string(nil), policy.OperationRecord...)
+
+	return func(c *gin.Context) {
+		c.Set(policyContextKey, policy)
+		c.Next()
+	}
+}

--- a/internal/http/requestlog/policy.go
+++ b/internal/http/requestlog/policy.go
@@ -1,0 +1,42 @@
+package requestlog
+
+import "github.com/gin-gonic/gin"
+
+// Destination identifies a request-body logging consumer.
+type Destination uint8
+
+const (
+	// ErrorLog selects fields allowed in application error logs.
+	ErrorLog Destination = iota
+	// OperationRecord selects fields allowed in persisted operation records.
+	OperationRecord
+)
+
+// Policy defines allowed JSON paths for each logging destination.
+type Policy struct {
+	ErrorLog        []string
+	OperationRecord []string
+}
+
+const policyContextKey = "request_log_policy"
+
+func fieldsFor(c *gin.Context, destination Destination) ([]string, bool) {
+	value, ok := c.Get(policyContextKey)
+	if !ok {
+		return nil, false
+	}
+
+	policy, ok := value.(Policy)
+	if !ok {
+		return nil, false
+	}
+
+	switch destination {
+	case ErrorLog:
+		return policy.ErrorLog, true
+	case OperationRecord:
+		return policy.OperationRecord, true
+	default:
+		return nil, true
+	}
+}

--- a/internal/http/requestlog/policy_test.go
+++ b/internal/http/requestlog/policy_test.go
@@ -1,0 +1,46 @@
+package requestlog
+
+import (
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithPolicyDoesNotConsumeRequestBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest("POST", "/", strings.NewReader("request body"))
+	policy := Policy{
+		ErrorLog:        []string{"email"},
+		OperationRecord: []string{"name"},
+	}
+	middleware := WithPolicy(policy)
+	policy.ErrorLog[0] = "password"
+	policy.OperationRecord[0] = "token"
+
+	middleware(c)
+
+	body, err := io.ReadAll(c.Request.Body)
+	require.NoError(t, err)
+	require.Equal(t, "request body", string(body))
+	errorLogFields, hasPolicy := fieldsFor(c, ErrorLog)
+	require.True(t, hasPolicy)
+	require.Equal(t, []string{"email"}, errorLogFields)
+	operationRecordFields, hasPolicy := fieldsFor(c, OperationRecord)
+	require.True(t, hasPolicy)
+	require.Equal(t, []string{"name"}, operationRecordFields)
+}
+
+func TestFieldsForWithoutPolicy(t *testing.T) {
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+
+	fields, hasPolicy := fieldsFor(c, ErrorLog)
+
+	require.False(t, hasPolicy)
+	require.Nil(t, fields)
+}

--- a/internal/http/response/error_response.go
+++ b/internal/http/response/error_response.go
@@ -1,13 +1,11 @@
 package response
 
 import (
-	"bytes"
-	"encoding/json"
-	"io"
 	"net/http"
 	"strconv"
 	"strings"
 
+	"github.com/chan-jui-huang/go-backend-framework/v3/internal/http/requestlog"
 	"github.com/chan-jui-huang/go-backend-package/v2/pkg/stacktrace"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
@@ -81,30 +79,10 @@ func (er *ErrorResponse) StatusCode() int {
 func (er *ErrorResponse) MakeLogFields(c *gin.Context, fields ...zap.Field) []zap.Field {
 	req := c.Request
 
-	var requestBody []byte
 	var internalFields []zap.Field
-	if bodyValue, ok := c.Get(gin.BodyBytesKey); ok {
-		if bodyBytes, ok := bodyValue.([]byte); ok {
-			requestBody = bodyBytes
-		}
-	} else if req.Body != nil {
-		body, err := io.ReadAll(req.Body)
-		if err != nil {
-			internalFields = append(internalFields, zap.NamedError("request_body_read_error", err))
-		} else {
-			requestBody = body
-		}
-	}
-
-	if requestBody != nil && json.Valid(requestBody) {
-		buffer := bytes.NewBuffer(make([]byte, 0, len(requestBody)))
-		err := json.Compact(buffer, requestBody)
-		if err != nil {
-			internalFields = append(internalFields, zap.NamedError("request_body_compact_error", err))
-			requestBody = nil
-		} else {
-			requestBody = buffer.Bytes()
-		}
+	requestBody, err := requestlog.Filter(c, requestlog.ErrorLog)
+	if err != nil {
+		internalFields = append(internalFields, zap.NamedError("request_body_filter_error", err))
 	}
 
 	debug := er.debug
@@ -129,8 +107,10 @@ func (er *ErrorResponse) MakeLogFields(c *gin.Context, fields ...zap.Field) []za
 		zap.String("method", req.Method),
 		zap.String("path", req.URL.Path),
 		zap.String("query_string", req.URL.Query().Encode()),
-		zap.ByteString("request_body", requestBody),
 		zap.Strings("stacktrace", stacktraceValue),
+	}
+	if len(requestBody) > 0 {
+		baseFields = append(baseFields, zap.ByteString("request_body", requestBody))
 	}
 	baseFields = append(baseFields, internalFields...)
 	baseFields = append(baseFields, fields...)

--- a/internal/http/response/error_response_test.go
+++ b/internal/http/response/error_response_test.go
@@ -1,0 +1,32 @@
+package response
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/chan-jui-huang/go-backend-framework/v3/internal/http/requestlog"
+	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorResponseMakeLogFieldsFiltersRequestBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest("POST", "/api/user/login", nil)
+	c.Set(gin.BodyBytesKey, []byte("{\"email\":\"john@test.com\",\"password\":\"secret\"}"))
+	requestlog.WithPolicy(requestlog.Policy{ErrorLog: []string{"email"}})(c)
+	errResp := NewErrorResponse(BadRequest, errors.New("bad request"), nil, false)
+
+	fields := errResp.MakeLogFields(c)
+
+	var requestBody []byte
+	for _, field := range fields {
+		if field.Key == "request_body" {
+			requestBody = field.Interface.([]byte)
+		}
+	}
+	require.JSONEq(t, "{\"email\":\"john@test.com\"}", string(requestBody))
+	require.NotContains(t, string(requestBody), "secret")
+}

--- a/internal/http/route/user/api_route.go
+++ b/internal/http/route/user/api_route.go
@@ -3,6 +3,7 @@ package user
 import (
 	"github.com/chan-jui-huang/go-backend-framework/v3/internal/http/controller/user"
 	"github.com/chan-jui-huang/go-backend-framework/v3/internal/http/middleware"
+	"github.com/chan-jui-huang/go-backend-framework/v3/internal/http/requestlog"
 	"github.com/gin-gonic/gin"
 )
 
@@ -37,9 +38,13 @@ func NewRouter(
 }
 
 func (r *Router) AttachRoutes() {
-	r.router.POST("register", r.registerHandler.Handle)
-	r.router.POST("login", r.loginHandler.Handle)
+	r.router.POST("register", requestlog.WithPolicy(requestlog.Policy{
+		ErrorLog: []string{"name", "email"},
+	}), r.registerHandler.Handle)
+	r.router.POST("login", requestlog.WithPolicy(requestlog.Policy{
+		ErrorLog: []string{"email"},
+	}), r.loginHandler.Handle)
 	r.router.GET("me", r.authentication.Handle(), r.getMeHandler.Handle)
 	r.router.PUT("", r.authentication.Handle(), r.updateHandler.Handle)
-	r.router.PUT("password", r.authentication.Handle(), r.updatePassword.Handle)
+	r.router.PUT("password", requestlog.WithPolicy(requestlog.Policy{}), r.authentication.Handle(), r.updatePassword.Handle)
 }


### PR DESCRIPTION
- Add requestlog filtering with allowlist policies and default safe JSON body logging
- Register user auth route policies for register, login, and password update requests
- Update error response logging to include filtered request body fields
- Cover filtering, defensive policy copying, and error response behavior with tests